### PR TITLE
[add] We can get categories list

### DIFF
--- a/lib/cat_api/categories.rb
+++ b/lib/cat_api/categories.rb
@@ -1,0 +1,11 @@
+class CatAPI::Categories
+  attr_reader :results
+
+  def initialize(xml)
+    @results = []
+    xml.xpath('//name').map do |name|
+      results.push(name.text)
+    end
+  end
+
+end

--- a/lib/cat_api/client.rb
+++ b/lib/cat_api/client.rb
@@ -11,7 +11,6 @@ class CatAPI::Client
   def initialize(defaults={})
     @defaults = defaults
     response = get "#{ BASE_URL }categories/list"
-    # @categories = CatAPI::Categories.new( Nokogiri::XML(response) )
     @categories = CatAPI::Categories.new( Nokogiri::XML(response) ).results
   end
 

--- a/lib/cat_api/client.rb
+++ b/lib/cat_api/client.rb
@@ -1,13 +1,18 @@
 require 'rest-client'
 require 'nokogiri'
 require 'cat_api/image_search'
+require 'cat_api/categories'
 
 class CatAPI::Client
+  attr_reader :categories
 
   BASE_URL = 'http://thecatapi.com/api/'
 
   def initialize(defaults={})
     @defaults = defaults
+    response = get "#{ BASE_URL }categories/list"
+    # @categories = CatAPI::Categories.new( Nokogiri::XML(response) )
+    @categories = CatAPI::Categories.new( Nokogiri::XML(response) ).results
   end
 
   def get_images(options={})


### PR DESCRIPTION
Hi, I like this gem "cat_api".

When i use category, i need to check this list.
http://thecatapi.com/api/categories/list

``` ruby
client = CatAPI.new
p client.categories
# ["hats", "space", "funny", "sunglasses", "boxes", "caturday", "ties", "dream", "kittens", "sinks", "clothes"]
```

I added "categories" variable. Thanks to this variable, we can use easily categories. 
